### PR TITLE
Harden runtime annotation and tileset lifecycles

### DIFF
--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Annotations/ITwinAnnotation.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Annotations/ITwinAnnotation.cpp
@@ -67,7 +67,6 @@ AITwinAnnotation::AITwinAnnotation()
 	widgetComponent->SetPivot(FVector2D(0.0f, 0.0f)); // Pivot at bottom center (pin position)
 	widgetComponent->SetVisibility(false); // Hidden by default until BeginPlay
 
-	BuildWidget();
 }
 
 void AITwinAnnotation::BeginPlay()
@@ -75,6 +74,7 @@ void AITwinAnnotation::BeginPlay()
 	Super::BeginPlay();
 	SetTickGroup(ETickingGroup::TG_PostUpdateWork);
 	
+	BuildWidget();
 	// Build the appropriate widget type based on settings
 	InitWorldSpaceWidget();
 	
@@ -89,11 +89,27 @@ void AITwinAnnotation::BeginPlay()
 	}
 }
 
+	void AITwinAnnotation::EndPlay(const EEndPlayReason::Type EndPlayReason)
+	{
+	  ReleaseWidget();
+	  Super::EndPlay(EndPlayReason);
+	}
+
 void AITwinAnnotation::BuildWidget()
 {
+	  if (onScreen)
+		  return;
+
+	  UWorld* World = GetWorld();
+	  if (!World)
+		  return;
+
 	// Build viewport-based widget (legacy approach)
-	onScreen = CreateWidget<UITwin2DAnnotationWidgetImpl>(GetWorld(), LoadClass <UITwin2DAnnotationWidgetImpl> (nullptr,
-		TEXT("/Script/UMGEditor.WidgetBlueprint'/ITwinForUnreal/ITwin/Annotations/ITwin2DAnnotationWidget.ITwin2DAnnotationWidget_C'")));
+	  TSubclassOf<UITwin2DAnnotationWidgetImpl> WidgetClass = LoadClass<UITwin2DAnnotationWidgetImpl>(nullptr,
+		  TEXT("/ITwinForUnreal/ITwin/Annotations/ITwin2DAnnotationWidget.ITwin2DAnnotationWidget_C"));
+	  if (!WidgetClass)
+		  return;
+	  onScreen = CreateWidget<UITwin2DAnnotationWidgetImpl>(World, WidgetClass);
 	if (onScreen)
 	{
 		if (CustomFontObject)
@@ -101,6 +117,15 @@ void AITwinAnnotation::BuildWidget()
 			onScreen->SetFontObject(CustomFontObject);
 		}
 		onScreen->SetText(content);
+	}
+}
+
+void AITwinAnnotation::ReleaseWidget()
+{
+	if (onScreen)
+	{
+					onScreen->RemoveFromParent();
+					onScreen = nullptr;
 	}
 }
 

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinDigitalTwinManager.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinDigitalTwinManager.cpp
@@ -194,7 +194,8 @@ void AITwinDigitalTwinManager::ResetITwin()
 
 	const auto ChildrenCopy = Children;
 	for (auto& Child : ChildrenCopy)
-		GetWorld()->DestroyActor(Child);
+		if (AActor* ChildActor = Child.Get())
+			GetWorld()->DestroyActor(ChildActor);
 	Children.Empty();
 }
 

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinDynamicShadingProperty.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinDynamicShadingProperty.cpp
@@ -218,7 +218,13 @@ bool FITwinDynamicShadingProperty<DataType, NumChannels>::UpdateTexture()
 	{
 		return false;
 	}
-	auto* TextureRHI = ((FTexture2DResource*)Texture->GetResource())->GetTexture2DRHI();
+	FTextureResource* TextureResource = Texture->GetResource();
+	if (!TextureResource)
+	{
+		return true;
+	}
+
+	auto* TextureRHI = static_cast<FTexture2DResource*>(TextureResource)->GetTexture2DRHI();
 	// tested in UpdateTextureRegions too but bNeedUpdate requires this early exit
 	if (!TextureRHI)
 	{

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinGoogle3DTileset.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinGoogle3DTileset.cpp
@@ -439,7 +439,10 @@ AITwinGoogle3DTileset::AITwinGoogle3DTileset()
 AITwinGoogle3DTileset::~AITwinGoogle3DTileset()
 {
 }
-
+	if (Impl)
+	{
+		 Impl->ClippingHelper.Reset();
+	}
 void AITwinGoogle3DTileset::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
@@ -460,7 +463,10 @@ void AITwinGoogle3DTileset::EndPlay(const EEndPlayReason::Type EndPlayReason)
 {
 	Super::EndPlay(EndPlayReason);
 }
-
+	if (Impl)
+	{
+		 Impl->ClippingHelper.Reset();
+	}
 void AITwinGoogle3DTileset::SetActorHiddenInGame(bool bNewHidden)
 {
 	Super::SetActorHiddenInGame(bNewHidden);

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinIModelInternals.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinIModelInternals.h
@@ -109,7 +109,7 @@ public:
 
 	enum class E4DScheduleStatus
 	{
-		Unknown, Loading, Finished, NoneOrEmpty
+		Unknown, Loading, Finished, Failed, NoneOrEmpty
 	};
 	void Update4DScheduleDownloadStatus(E4DScheduleStatus Sched4DStatus, double PercentComplete = 0.);
 	bool AreSynchro4DSchedulesMetadataLoadedOrCancelled() const;

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinRealityData.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinRealityData.cpp
@@ -469,7 +469,8 @@ void AITwinRealityData::Destroyed()
 	}
 	const auto ChildrenCopy = Children;
 	for (auto& Child: ChildrenCopy)
-		GetWorld()->DestroyActor(Child);
+		  if (Child)
+			  GetWorld()->DestroyActor(Child);
 }
 
 UITwinClipping3DTilesetHelper* AITwinRealityData::GetClippingHelper() const

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinSceneTile.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinSceneTile.cpp
@@ -1074,7 +1074,7 @@ void FITwinSceneTile::ShowElements(std::unordered_set<ITwinElementID> const& InE
 		{
 			FeaturesToUnHide = FindElementFeaturesSLOW(InID);
 		}
-		if (FeaturesToUnHide && !FeaturesToUnHide->Features.empty())
+		if (FeaturesToUnHide && !FeaturesToUnHide->Features.empty() && SelectingAndHiding)
 		{
 			CreateAndSetSelectingAndHiding(*FeaturesToUnHide, TextureNeeds, ITwin::COLOR_UNSELECT_ELEMENT_BGRA, false);
 		}

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Public/Annotations/ITwinAnnotation.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Public/Annotations/ITwinAnnotation.h
@@ -153,9 +153,11 @@ public:
 
 protected:
 	virtual void BeginPlay() override;
+	 virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 	virtual void Tick(float DeltaTime) override;
 
 	void BuildWidget();
+	 void ReleaseWidget();
 	void InitWorldSpaceWidget();
 
 	void UpdateDisplay();


### PR DESCRIPTION
# Purpose
Fix runtime lifecycle problems involving the on-screen annotation widget, tilesets, textures, clipping helpers, and dynamically created actors.

The widget involved is ITwin2DAnnotationWidget, implemented by UITwin2DAnnotationWidgetImpl and created for each AITwinAnnotation. The widget was previously constructed from the actor constructor. That was too early in Unreal’s lifecycle because the actor could be created before the world, schedule data, widget class, or related runtime objects were fully available.

The annotation widget is now created during BeginPlay, after the actor has entered a valid runtime world. The construction path checks that the world and widget class are valid and prevents the same widget from being created more than once.

The widget is also explicitly removed during EndPlay. This is important when starting and stopping PIE sessions repeatedly. Without cleanup, a widget could remain attached to the viewport after its actor was destroyed, fail to initialize in the next session, or be created a second time and appear duplicated.

The change also adds safety checks to runtime cleanup and rendering paths. Child actors, texture resources, clipping helpers, and other dependent objects can be destroyed or become unavailable while models, schedules, and tilesets are loading or unloading. The added checks prevent invalid object access and invalid destruction during PIE restarts, level teardown, model reloads, and asynchronous initialization.

The overall purpose is to ensure that runtime objects are created only after their required dependencies are available and are released when their owning actors leave the world.