### PR TITLE
Apply saved view visibility state to runtime objects

### DIFF
--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinSavedView.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinSavedView.cpp
@@ -51,6 +51,7 @@ public:
 	{
 		None,
 		Move,
+		  ApplyVisibility,
 		Rename
 	};
 	AITwinSavedView& Owner;
@@ -66,7 +67,8 @@ public:
 	{
 		const auto ChildrenCopy = Owner.Children;
 		for (auto& Child : ChildrenCopy)
-			Owner.GetWorld()->DestroyActor(Child);
+			  if (AActor* ChildActor = Child.Get())
+				  Owner.GetWorld()->DestroyActor(ChildActor);
 		Owner.Children.Empty();
 	}
 	void ApplyScheduleTime()
@@ -164,6 +166,13 @@ namespace
 
 		return Result;
 	}
+
+	  AITwinIModel* ResolveSavedViewIModel(const AITwinSavedView& SavedViewActor)
+	  {
+		  if (AITwinIModel* const AttachedIModel = Cast<AITwinIModel>(SavedViewActor.GetAttachParentActor()))
+			  return AttachedIModel;
+		  return Cast<AITwinIModel>(SavedViewActor.GetOwner());
+	  }
 
 	FString ToString(FPerModelCategoryVisibilityProps const& PerModelCat)
 	{
@@ -285,6 +294,9 @@ void AITwinSavedView::OnSavedViewRetrieved(bool bSuccess, FSavedView const& Save
 	case FImpl::EPendingOperation::Move:
 		MoveToSavedView();
 		break;
+	  case FImpl::EPendingOperation::ApplyVisibility:
+		  ApplySavedViewVisibility();
+		  break;
 	case FImpl::EPendingOperation::Rename:
 		RenameSavedView();
 		break;
@@ -452,16 +464,33 @@ void AITwinSavedView::MoveToSavedView()
 			}
 		#endif // WITH_EDITOR
 		}
-		AITwinIModel* const iModel = Cast<AITwinIModel>(GetAttachParentActor());
 		BE_LOGI("ITwinAPI",
 			"Applying show/hide requirements from SavedView " << TCHAR_TO_UTF8(*GetActorNameOrLabel()));
-		HideElements(iModel, Impl->SavedViewData);
+		  ApplySavedViewVisibility();
 	}
 	else // fetch the saved view data before we can move to it
 	{
 		Impl->PendingOperation = FImpl::EPendingOperation::Move;
 		UpdateSavedView();
 	}
+}
+
+void AITwinSavedView::ApplySavedViewVisibility()
+{
+	if (SavedViewId.IsEmpty() && !Impl->bSavedViewTransformIsSet)
+	{
+					BE_LOGE("ITwinAPI", "ITwinSavedView has no SavedViewId - cannot apply saved view visibility");
+					return;
+	}
+
+	if (!Impl->bSavedViewTransformIsSet)
+	{
+					Impl->PendingOperation = FImpl::EPendingOperation::ApplyVisibility;
+					UpdateSavedView();
+					return;
+	}
+
+	HideElements(ResolveSavedViewIModel(*this), Impl->SavedViewData);
 }
 
 void AITwinSavedView::DeleteSavedView()

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Public/ITwinSavedView.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Public/ITwinSavedView.h
@@ -63,6 +63,11 @@ public:
 		BlueprintCallable)
 	void MoveToSavedView();
 
+	UFUNCTION(Category = "iTwin",
+		CallInEditor,
+		BlueprintCallable)
+	void ApplySavedViewVisibility();
+
 	//! UpdateSavedView() needs to be called at least once before calling RenameSavedView()
 	//! to set the savedView transform.
 	//! Note: Only saved views created with the plugin can be renamed, legacy saved views are not editable.


### PR DESCRIPTION
## Summary
- Add saved-view visibility application support.
- Expose the visibility operation through the saved-view runtime API.
- Preserve upstream `0.1.28` behavior and exclude assets/build artifacts.

## Validation
- `git diff --check` passes.
- No conflict markers or obvious binary/build artifacts.
- Secret-pattern scan found no credential-like values.
- Full Unreal build/tests remain pending because the local UE 5.6 environment has a Marketplace Cesium plugin collision under `Engine/Plugins/Marketplace`.

## Update
Add a Blueprint-callable operation that applies the visibility state from a saved view created in Bentley Infrastructure Cloud.

A saved view can contain visibility rules for models, categories, and individual elements. Applying those rules in Unreal allows the same view configuration used in Bentley Infrastructure Cloud to control what is displayed in the Unreal scene.

This supports workflows where certain elements need to be hidden without manually recreating the visibility rules in Blueprint or C++. For example, a saved view can be created to show only a particular building system, construction area, discipline, or phase of work, and that visibility configuration can then be applied to the corresponding Unreal iModel.

Visibility is handled separately from camera movement. The saved view can be used to hide and show elements while leaving the current Unreal camera position unchanged. This avoids forcing the user to move to the saved view whenever only its visibility configuration is needed.

The implementation also handles saved-view data that has not yet been downloaded. If the data is unavailable, the visibility operation is stored as a pending operation, the saved view is retrieved asynchronously, and the visibility state is applied after the response arrives.

The existing MoveToSavedView behavior also uses the same visibility operation, ensuring that saved-view visibility is applied consistently whether the saved view is being used for navigation or only as a visibility preset.