### PR TITLE
Preserve animation keys and improve schedule timeline import

### DIFF
--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinSynchro4DSchedules.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinSynchro4DSchedules.cpp
@@ -111,6 +111,11 @@ void UITwinSynchro4DSchedules::FImpl::UpdateGltfTunerRules()
 	AITwinIModel* IModel = Cast<AITwinIModel>(Owner.GetOwner());
 	if (!ensure(IModel))
 		return;
+  auto const RetuneIfVersionChanged = [this, IModel](int64_t const PreviousVersion)
+  {
+	  if (Internals.MinGltfTunerVersionForAnimation != PreviousVersion)
+		  IModel->Retune();
+  };
 	if (!ensure(Internals.GltfTuner))
 	{
 		// TODO_GCO: but existing tiles will not be setup for 4D :/
@@ -244,7 +249,9 @@ void UITwinSynchro4DSchedules::FImpl::UpdateGltfTunerRules()
 		AnimRules.anim4DGroups_.emplace_back(BeUtils::GltfTuner::Rules::Anim4DGroup{
 			std::move(NodeHandle.mapped()), std::move(NodeHandle.key()) });
 	}
+	auto const PreviousVersion = Internals.MinGltfTunerVersionForAnimation;
 	Internals.MinGltfTunerVersionForAnimation = Internals.GltfTuner->SetAnim4DRules(std::move(AnimRules));
+	RetuneIfVersionChanged(PreviousVersion);
 }
 
 static FITwinCoordConversions const& GetIModel2UnrealCoordConv(UITwinSynchro4DSchedules& Owner)

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinSynchro4DSchedulesTimelineBuilder.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinSynchro4DSchedulesTimelineBuilder.cpp
@@ -31,6 +31,77 @@
 
 namespace Detail {
 
+bool LessAnimationKey(FIModelElementsKey const& A, FIModelElementsKey const& B)
+{
+	if (A.Key.index() == B.Key.index())
+	{
+		bool Result = false;
+		std::visit([&B, &Result](auto&& Key)
+			{
+				using T = std::decay_t<decltype(Key)>;
+				Result = Key < std::get<T>(B.Key);
+			},
+			A.Key);
+		return Result;
+	}
+	return A.Key.index() < B.Key.index();
+}
+
+void InsertAnimationKey(FITwinElement::FAnimKeysVec& AnimationKeys, FIModelElementsKey const& AnimationKey)
+{
+	auto const FirstGreaterOrEqual = std::lower_bound(AnimationKeys.begin(), AnimationKeys.end(), AnimationKey,
+		LessAnimationKey);
+	if (FirstGreaterOrEqual == AnimationKeys.end() || AnimationKey != *FirstGreaterOrEqual)
+		AnimationKeys.insert(FirstGreaterOrEqual, AnimationKey);
+}
+
+void ReplaceAnimationKey(FITwinElement::FAnimKeysVec& AnimationKeys,
+	FIModelElementsKey const& ExistingAnimationKey, FIModelElementsKey const& NewAnimationKey)
+{
+	if (ExistingAnimationKey == NewAnimationKey)
+		return;
+	auto ExistingAnimationKeyIt = std::lower_bound(AnimationKeys.begin(), AnimationKeys.end(), ExistingAnimationKey,
+		LessAnimationKey);
+	if (!ensure(ExistingAnimationKeyIt != AnimationKeys.end() && ExistingAnimationKey == *ExistingAnimationKeyIt))
+	{
+		InsertAnimationKey(AnimationKeys, NewAnimationKey);
+		return;
+	}
+	AnimationKeys.erase(ExistingAnimationKeyIt);
+	InsertAnimationKey(AnimationKeys, NewAnimationKey);
+}
+
+void AddAnimationKeyToAnimatedParents(FITwinSceneMapping& SceneMapping, ITwinScene::ElemIdx ParentIdx,
+	FIModelElementsKey const& ExistingAnimationKey, FIModelElementsKey const& NewAnimationKey)
+{
+	while (ITwinScene::NOT_ELEM != ParentIdx)
+	{
+		auto& ParentElem = SceneMapping.ElementFor(ParentIdx);
+		auto const ExistingAnimationKeyIt = std::lower_bound(ParentElem.AnimationKeys.begin(),
+			ParentElem.AnimationKeys.end(), ExistingAnimationKey, LessAnimationKey);
+		if (ExistingAnimationKeyIt == ParentElem.AnimationKeys.end()
+			|| ExistingAnimationKey != *ExistingAnimationKeyIt)
+			break;
+		InsertAnimationKey(ParentElem.AnimationKeys, NewAnimationKey);
+		ParentIdx = ParentElem.ParentInVec;
+	}
+}
+
+void ReassignAnimationKeyForSplit(FITwinSceneMapping& SceneMapping, FElementsGroup const& ElementsSubGroup,
+	FIModelElementsKey const& ExistingAnimationKey, FIModelElementsKey const& NewAnimationKey)
+{
+	for (ITwinElementID const ElemID : ElementsSubGroup)
+	{
+		ITwinScene::ElemIdx ElemIdx = ITwinScene::NOT_ELEM;
+		auto* Elem = SceneMapping.GetElementForSLOW(ElemID, &ElemIdx);
+		if (!ensure(Elem))
+			continue;
+		ReplaceAnimationKey(Elem->AnimationKeys, ExistingAnimationKey, NewAnimationKey);
+		AddAnimationKeyToAnimatedParents(SceneMapping, Elem->ParentInVec,
+			ExistingAnimationKey, NewAnimationKey);
+	}
+}
+
 template<typename ElemDesignationContainer>
 void InsertAnimatedMeshSubElemsRecursively(FIModelElementsKey const& AnimationKey,
 	FITwinSceneMapping& Scene, ElemDesignationContainer const& Elements,
@@ -53,12 +124,7 @@ void InsertAnimatedMeshSubElemsRecursively(FIModelElementsKey const& AnimationKe
 		// Insert without duplication, and using a deterministic ordering, because concurrent 4D queries could
 		// obviously be received in an arbitrary order: necessary for CreateTimelineKeyframesWithTaskDependencies
 		// which can thus compare the Elem.AnimationKeys arrays directly.
-		auto const FirstGreaterOrEqual = std::lower_bound(Elem.AnimationKeys.begin(), Elem.AnimationKeys.end(),
-														  AnimationKey);
-		if (FirstGreaterOrEqual == Elem.AnimationKeys.end() || AnimationKey != (*FirstGreaterOrEqual))
-		{
-			Elem.AnimationKeys.insert(FirstGreaterOrEqual, AnimationKey);
-		}
+		InsertAnimationKey(Elem.AnimationKeys, AnimationKey);
 		// When pre-fetching bindings, bHasMesh is not set at this point, since we may not have received a tile with
 		// it yet. Let's rely on Elem.BBox instead. We used to rely on the list of child elements, assuming only leaves
 		// had geometries, but this proved wrong (ADO#2020662).
@@ -190,36 +256,34 @@ public:
 			return false;
 		ensure(SplitElemGroups->size() > 1);
 		bool bUseExisting = true;
-		FIModelElementsKey const UnsplitAnimKey = ElemTimeline.GetIModelElementsKey();
-		FITwinElementTimeline::FBindings const UnsplitBindings = ElemTimeline.GetAnimationBindings();
+		FIModelElementsKey const ExistingAnimationKey = ElemTimeline.GetIModelElementsKey();
+		FITwinElementTimeline::FBindings const ExistingAnimationBindings = ElemTimeline.GetAnimationBindings();
 		for (auto& [CommonAnimationKeys, ElementsSubGroup] : (*SplitElemGroups))
 		{
 			if (!KeyframedSubgroups.insert(ElementsSubGroup).second) // !inserted = already present thus handled
 				continue;
-			FIModelElementsKey const SubgroupAnimKey(Schedule.NumGroups());
-			for (auto&& Elem : ElementsSubGroup)
-			{
-				auto&& AnimKeys = SceneMapping.ElementForSLOW(Elem).AnimationKeys;
-				std::replace(AnimKeys.begin(), AnimKeys.end(), UnsplitAnimKey, SubgroupAnimKey);
-			}
 			FITwinElementTimeline* pSubgroupTimeline;
-			if (bUseExisting)
+			bool const bReusingExistingTimeline = bUseExisting;
+			if (bReusingExistingTimeline)
 			{
 				bUseExisting = false;
-				MainTimeline.ResetElementTimelineFor(TimelineIndex, SubgroupAnimKey);
 				ElemTimeline.IModelElementsRef() = ElementsSubGroup;
 				pSubgroupTimeline = &ElemTimeline;
 			}
 			else
 			{
-				pSubgroupTimeline = &MainTimeline.ElementTimelineFor(SubgroupAnimKey, ElementsSubGroup);
+				FIModelElementsKey const SubgroupElementsKey(Schedule.NumGroups());
+				ReassignAnimationKeyForSplit(SceneMapping, ElementsSubGroup,
+					ExistingAnimationKey, SubgroupElementsKey);
+				pSubgroupTimeline = &MainTimeline.ElementTimelineFor(SubgroupElementsKey, ElementsSubGroup);
+				pSubgroupTimeline->AnimationBindings() = ExistingAnimationBindings;
 			}
 			for (auto&& AnimationKey : CommonAnimationKeys)
 			{
-				if (AnimationKey == UnsplitAnimKey) // timeline reused ie. no longer mapped to AnimationKey!
+								if (bReusingExistingTimeline && AnimationKey == ExistingAnimationKey)
 				{
 					pSubgroupTimeline->AnimationBindings().insert(pSubgroupTimeline->AnimationBindings().end(),
-						UnsplitBindings.begin(), UnsplitBindings.end());
+						ExistingAnimationBindings.begin(), ExistingAnimationBindings.end());
 				}
 				else if (auto* Timeline = MainTimeline.GetElementTimelineFor(AnimationKey))
 					pSubgroupTimeline->AnimationBindings().insert(pSubgroupTimeline->AnimationBindings().end(),
@@ -228,7 +292,7 @@ public:
 			Schedule.CreateNextGroup(std::move(ElementsSubGroup));
 			bool const bHasOnlyNeutralTasks = Schedule.HasOnlyNeutralBindings(
 				pSubgroupTimeline->AnimationBindings().begin(), pSubgroupTimeline->AnimationBindings().end());
-			for (size_t AnimationBindingIndex : ElemTimeline.AnimationBindings())
+						for (size_t AnimationBindingIndex : pSubgroupTimeline->AnimationBindings())
 			{
 				CreateAnimationBindingKeyframes(Schedule, *pSubgroupTimeline, AnimationBindingIndex,
 												bHasOnlyNeutralTasks);

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinSynchro4DSchedulesTimelineBuilder.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinSynchro4DSchedulesTimelineBuilder.h
@@ -21,6 +21,7 @@
 using FOnElementsTimelineModified =
 	std::function<void(FITwinElementTimeline&,  std::vector<ITwinElementID> const*)>;
 struct FITwinCoordConversions;
+class FITwinSceneMapping;
 class FITwinSchedule;
 class FITwinScheduleStats;
 using FSchedLock = std::lock_guard<std::recursive_mutex>;
@@ -50,6 +51,7 @@ public:
 private:
 	friend class FITwinSynchro4DSchedulesInternals;
 	friend class FSynchro4DImportTestHelper;
+	friend class FScheduleTimelineBuilderTestAccess;
 
 	class FImpl;
 	TPimplPtr<FImpl> Impl;
@@ -60,6 +62,13 @@ private:
 	void AddAnimationBindingToTimeline(FITwinSchedule const& Schedule, size_t const AnimationBindingIndex,
 									   FSchedLock& Lock);
 	void OnReceivedScheduleStats(FITwinScheduleStats const& Stats, FSchedLock&);
+#if WITH_TESTS
+	bool TestOnlyCreateTimelineKeyframesWithTaskDependencies(
+		FITwinSceneMapping& SceneMapping,
+		FITwinSchedule& Schedule,
+		FITwinElementTimeline& ElemTimeline,
+		std::unordered_set<FElementsGroup>& KeyframedSubgroups);
+#endif
 	FITwinScheduleTimelineBuilder();
 	bool IsUnitTesting() const;
 };

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Tests/TimelineTest.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Tests/TimelineTest.cpp
@@ -9,14 +9,36 @@
 // From vue.git/viewer/Code/Tools/UnitTests/ScheduleTests.cpp
 
 #include <CoreMinimal.h>
+#include <ITwinSceneMapping.h>
+#include <ITwinSynchro4DSchedulesTimelineBuilder.h>
+#include <ITwinUtilityLibrary.h>
 #include <Math/Vector.h>
 #include <Misc/AutomationTest.h>
 #include <Misc/LowLevelTestAdapter.h>
 
+#include <array>
+
 #include <Hashing/UnrealMath.h>
+#include <Timeline/SchedulesStructs.h>
+#include <Timeline/SchedulesStructs.inl>
 #include <Timeline/Definition.h>
 
-#ifdef WITH_TESTS
+#if WITH_TESTS
+
+class FScheduleTimelineBuilderTestAccess
+{
+public:
+	static bool CreateTimelineKeyframesWithTaskDependencies(
+		FITwinScheduleTimelineBuilder& Builder,
+		FITwinSceneMapping& SceneMapping,
+		FITwinSchedule& Schedule,
+		FITwinElementTimeline& ElemTimeline,
+		std::unordered_set<FElementsGroup>& KeyframedSubgroups)
+	{
+		return Builder.TestOnlyCreateTimelineKeyframesWithTaskDependencies(
+			SceneMapping, Schedule, ElemTimeline, KeyframedSubgroups);
+	}
+};
 
 namespace ITwin::Timeline {
 
@@ -478,6 +500,181 @@ void MainTimelineAddSpec::Define()
 		});
 	It("should span the right time range", [this]() {
 			TestTrue("get time range", std::make_pair(100., 300.) == Timeline->GetTimeRange());
+		});
+}
+
+BEGIN_DEFINE_SPEC(HasOnlyNeutralBindingsSpec, "Bentley.ITwinForUnreal.ITwinRuntime.Timeline",
+				  EAutomationTestFlags::EngineFilter | EAutomationTestFlags_ApplicationContextMask)
+	FITwinSchedule Schedule;
+END_DEFINE_SPEC(HasOnlyNeutralBindingsSpec)
+
+void HasOnlyNeutralBindingsSpec::Define()
+{
+	BeforeEach([this]()
+		{
+			Schedule = {};
+			Schedule.AppearanceProfiles.resize(3);
+			Schedule.AppearanceProfiles[0].ProfileType = EProfileAction::Neutral;
+			Schedule.AppearanceProfiles[1].ProfileType = EProfileAction::Neutral;
+			Schedule.AppearanceProfiles[2].ProfileType = EProfileAction::Install;
+
+			Schedule.AnimationBindings.resize(3);
+			Schedule.AnimationBindings[0].AppearanceProfileInVec = 0;
+			Schedule.AnimationBindings[1].AppearanceProfileInVec = 1;
+			Schedule.AnimationBindings[2].AppearanceProfileInVec = 2;
+		});
+
+	It("checks only the provided binding range", [this]()
+		{
+			const std::array<size_t, 2> NeutralBindings{ 0, 1 };
+
+			TestTrue(
+				"neutral-only subset should stay neutral even if another binding elsewhere is non-neutral",
+				Schedule.HasOnlyNeutralBindings(NeutralBindings.begin(), NeutralBindings.end()));
+		});
+
+	It("returns false when the provided binding range contains a non-neutral task", [this]()
+		{
+			const std::array<size_t, 2> MixedBindings{ 0, 2 };
+
+			TestFalse(
+				"subset containing a non-neutral binding should not be treated as neutral-only",
+				Schedule.HasOnlyNeutralBindings(MixedBindings.begin(), MixedBindings.end()));
+	});
+}
+
+BEGIN_DEFINE_SPEC(TimelineBuilderRegressionSpec, "Bentley.ITwinForUnreal.ITwinRuntime.Timeline",
+				  EAutomationTestFlags::EngineFilter | EAutomationTestFlags_ApplicationContextMask)
+END_DEFINE_SPEC(TimelineBuilderRegressionSpec)
+
+void TimelineBuilderRegressionSpec::Define()
+{
+	It("hashes equal element groups independently of insertion order", [this]()
+		{
+			FElementsGroup GroupA{ ITwinElementID(1), ITwinElementID(2), ITwinElementID(3) };
+			FElementsGroup GroupB{ ITwinElementID(3), ITwinElementID(1), ITwinElementID(2) };
+			std::hash<FElementsGroup> Hasher;
+
+			TestTrue("equal groups should compare equal", GroupA == GroupB);
+			TestEqual("equal groups should share the same hash",
+				static_cast<int64>(Hasher(GroupA)), static_cast<int64>(Hasher(GroupB)));
+
+			std::unordered_set<FElementsGroup> SeenGroups;
+			SeenGroups.insert(GroupA);
+			SeenGroups.insert(GroupB);
+			TestEqual("unordered_set should deduplicate equal groups", static_cast<int32>(SeenGroups.size()), 1);
+		});
+
+	It("can uninitialize a unit-test timeline builder without an owner", [this]()
+		{
+			FITwinCoordConversions CoordConversions;
+			FITwinScheduleTimelineBuilder Builder =
+				FITwinScheduleTimelineBuilder::CreateForUnitTesting(CoordConversions);
+			Builder.Initialize(FOnElementsTimelineModified{});
+			Builder.Uninitialize();
+			TestTrue("unit-test builder cleanup should not require an owner", true);
+		});
+
+	It("keeps the first divergent element in the split subgroup", [this]()
+		{
+			FITwinCoordConversions CoordConversions;
+			FITwinScheduleTimelineBuilder Builder =
+				FITwinScheduleTimelineBuilder::CreateForUnitTesting(CoordConversions);
+			FITwinSceneMapping SceneMapping(false);
+			FITwinSchedule Schedule;
+
+			Schedule.AppearanceProfiles.resize(2);
+			Schedule.AppearanceProfiles[0].ProfileType = EProfileAction::Neutral;
+			Schedule.AppearanceProfiles[1].ProfileType = EProfileAction::Install;
+
+			Schedule.Tasks.resize(2);
+			Schedule.Tasks[0].TimeRange = { 10., 20. };
+			Schedule.Tasks[1].TimeRange = { 30., 40. };
+
+			Schedule.AnimationBindings.resize(2);
+			Schedule.AnimationBindings[0].AppearanceProfileInVec = 0;
+			Schedule.AnimationBindings[0].TaskInVec = 0;
+			Schedule.AnimationBindings[1].AppearanceProfileInVec = 1;
+			Schedule.AnimationBindings[1].TaskInVec = 1;
+
+			FIModelElementsKey const ExistingAnimationKey(ITwinElementID(100));
+			FIModelElementsKey const DivergentAnimationKey(ITwinElementID(200));
+			FElementsGroup AllElements{ ITwinElementID(1), ITwinElementID(2), ITwinElementID(3) };
+
+			auto& BaseTimeline = Builder.Timeline().ElementTimelineFor(ExistingAnimationKey, AllElements);
+			BaseTimeline.AnimationBindings().push_back(0);
+			auto& DivergentTimeline =
+				Builder.Timeline().ElementTimelineFor(DivergentAnimationKey, FElementsGroup{});
+			DivergentTimeline.AnimationBindings().push_back(1);
+			(void)DivergentTimeline;
+
+			SceneMapping.ElementForSLOW(ITwinElementID(1)).AnimationKeys = { ExistingAnimationKey };
+			SceneMapping.ElementForSLOW(ITwinElementID(2)).AnimationKeys = {
+				ExistingAnimationKey, DivergentAnimationKey
+			};
+			SceneMapping.ElementForSLOW(ITwinElementID(3)).AnimationKeys = {
+				ExistingAnimationKey, DivergentAnimationKey
+			};
+
+			std::unordered_set<FElementsGroup> KeyframedSubgroups;
+			TestTrue("mixed animation keys should trigger timeline splitting",
+				FScheduleTimelineBuilderTestAccess::CreateTimelineKeyframesWithTaskDependencies(
+					Builder, SceneMapping, Schedule, BaseTimeline, KeyframedSubgroups));
+
+			TestEqual("split should create one additional subgroup timeline",
+				static_cast<int32>(Builder.GetTimeline().GetContainer().size()), 2);
+			TestEqual("reused base timeline should keep only reference elements",
+				static_cast<int32>(BaseTimeline.GetIModelElements().size()), 1);
+			TestTrue("reference subgroup should keep element 1",
+				BaseTimeline.GetIModelElements().contains(ITwinElementID(1)));
+
+			FElementsGroup const ExpectedSplitGroup{ ITwinElementID(2), ITwinElementID(3) };
+			auto* SplitTimeline = Builder.GetTimeline().GetElementTimelineFor(FIModelElementsKey(size_t(0)));
+			TestTrue("split subgroup timeline should be created", nullptr != SplitTimeline);
+			if (!SplitTimeline)
+				return;
+
+			TestEqual("first divergent element should stay in the split subgroup",
+				static_cast<int32>(SplitTimeline->GetIModelElements().size()), 2);
+			TestTrue("split subgroup should contain element 2",
+				SplitTimeline->GetIModelElements().contains(ITwinElementID(2)));
+			TestTrue("split subgroup should contain element 3",
+				SplitTimeline->GetIModelElements().contains(ITwinElementID(3)));
+			TestTrue("split subgroup should be tracked as keyframed",
+				KeyframedSubgroups.contains(ExpectedSplitGroup));
+			TestEqual("split subgroup should inherit both relevant bindings",
+				static_cast<int32>(SplitTimeline->GetAnimationBindings().size()), 2);
+		});
+
+	It("skips task dependency splitting for timelines without resolved elements", [this]()
+		{
+			FITwinCoordConversions CoordConversions;
+			FITwinScheduleTimelineBuilder Builder =
+				FITwinScheduleTimelineBuilder::CreateForUnitTesting(CoordConversions);
+			FITwinSceneMapping SceneMapping(false);
+			FITwinSchedule Schedule;
+
+			Schedule.AppearanceProfiles.resize(2);
+			Schedule.AppearanceProfiles[0].ProfileType = EProfileAction::Neutral;
+			Schedule.AppearanceProfiles[1].ProfileType = EProfileAction::Install;
+
+			Schedule.AnimationBindings.resize(2);
+			Schedule.AnimationBindings[0].AppearanceProfileInVec = 0;
+			Schedule.AnimationBindings[1].AppearanceProfileInVec = 1;
+
+			FITwinElementTimeline& EmptyTimeline =
+				Builder.Timeline().ElementTimelineFor(FIModelElementsKey(ITwinElementID(100)), FElementsGroup{});
+			EmptyTimeline.AnimationBindings().push_back(0);
+			EmptyTimeline.AnimationBindings().push_back(1);
+
+			std::unordered_set<FElementsGroup> KeyframedSubgroups;
+			TestFalse("empty element timelines should fall back to normal keyframe creation",
+				FScheduleTimelineBuilderTestAccess::CreateTimelineKeyframesWithTaskDependencies(
+					Builder, SceneMapping, Schedule, EmptyTimeline, KeyframedSubgroups));
+			TestEqual("empty timelines should not create subgroup timelines",
+				static_cast<int32>(Builder.GetTimeline().GetContainer().size()), 1);
+			TestEqual("empty timelines should not mark any subgroup as keyframed",
+				static_cast<int32>(KeyframedSubgroups.size()), 0);
 		});
 }
 

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Timeline/SchedulesImport.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Timeline/SchedulesImport.cpp
@@ -556,7 +556,30 @@ void FITwinSchedulesImport::FImpl::RequestSchedules(ReusableJsonQueries::FStacki
 			{
 				const auto& SchedObj = SchedVal->AsObject();
 				FString IModelId;
-				JSON_GETSTR_OR(SchedObj, "iModelId", IModelId, continue)
+				if (!SchedObj->TryGetStringField(TEXT("iModelId"), IModelId) || IModelId.IsEmpty())
+				{
+					FString ScheduleId;
+					FString ScheduleName;
+					SchedObj->TryGetStringField(TEXT("id"), ScheduleId);
+					SchedObj->TryGetStringField(TEXT("name"), ScheduleName);
+					std::string Details;
+					if (!ScheduleId.IsEmpty())
+					{
+						Details += " (id=\"";
+						Details += TCHAR_TO_UTF8(*ScheduleId);
+						Details += "\")";
+					}
+					if (!ScheduleName.IsEmpty())
+					{
+						Details += " (name=\"";
+						Details += TCHAR_TO_UTF8(*ScheduleName);
+						Details += "\")";
+					}
+					BE_LOGW("ITwin4DImp", "Skipping schedule entry missing iModelId"
+						<< Details
+						<< " while querying schedules for iTwinId \"" << TCHAR_TO_UTF8(*ITwinId) << "\"");
+					continue;
+				}
 				if (IModelId == TargetedIModelId)
 				{
 					FString Id;
@@ -2087,8 +2110,9 @@ void FITwinSchedulesImport::FImpl::ResetConnection(FString const& ITwinAkaProjec
 				bool bConnectedSuccessfully, bool const bWillRetry /*= false*/)
 			{
 				FString StrError;
-				if (!AITwinServerConnection::CheckRequest(CompletedRequest, Response, bConnectedSuccessfully,
-					&StrError, bWillRetry))
+				bool const bRequestOK = AITwinServerConnection::CheckRequest(
+					CompletedRequest, Response, bConnectedSuccessfully, &StrError, bWillRetry);
+				if (!bRequestOK)
 				{
 					if (!bHasFetchingErrors && !bWillRetry)
 					{
@@ -2101,7 +2125,7 @@ void FITwinSchedulesImport::FImpl::ResetConnection(FString const& ITwinAkaProjec
 					}
 					return false;
 				}
-				return true;
+				return bRequestOK;
 			},
 			Mutex,
 			(!Owner->Owner || Owner->Owner->DebugRecordSessionQueries.IsEmpty()
@@ -2341,6 +2365,12 @@ FITwinSchedulesImport& FITwinSchedulesImport::operator=(FITwinSchedulesImport&& 
 bool FITwinSchedulesImport::IsReadyToQuery() const
 {
 	return Impl->Queries.Get() != nullptr;
+}
+
+void FITwinSchedulesImport::BeginShutdown()
+{
+	if (Impl->Queries)
+		Impl->Queries->BeginShutdown();
 }
 
 bool FITwinSchedulesImport::HasFinishedPrefetching() const

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Timeline/SchedulesImport.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Timeline/SchedulesImport.h
@@ -44,6 +44,7 @@ public:
 
 	/// Tells whether the connection information was set up and the structure is ready to start querying
 	bool IsReadyToQuery() const;
+	void BeginShutdown();
 	/// When pre-fetching everything, including animation bindings, tells whether everything has been queried
 	/// and all replies have been received from the server (including retries, in case of unsuccessful
 	/// requests). This doesn't mean all replies were successful: @see HasFetchingErrors.

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Timeline/SchedulesStructs.inl
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Timeline/SchedulesStructs.inl
@@ -14,10 +14,11 @@
 template<typename BindingIndexIterator>
 bool FITwinSchedule::HasOnlyNeutralBindings(BindingIndexIterator First, BindingIndexIterator Last) const
 {
-	return AnimationBindings.end() == std::find_if(
-		AnimationBindings.begin(), AnimationBindings.end(), [this](FAnimationBinding const& Binding)
+	return Last == std::find_if(
+		First, Last, [this](const auto& BindingIndex)
 		{
-			return EProfileAction::Neutral != this->AppearanceProfiles[Binding.AppearanceProfileInVec].ProfileType;
+			return EProfileAction::Neutral
+				!= this->AppearanceProfiles[this->AnimationBindings[BindingIndex].AppearanceProfileInVec].ProfileType;
 		});
 }
 
@@ -33,7 +34,7 @@ namespace Detail
 	};
 	using OptTimedProfile = std::optional<TimedProfile>;
 
-	void UpdateTimedProfiles(FScheduleTask const& Task, FScheduleTask const& OtherTask,
+	inline void UpdateTimedProfiles(FScheduleTask const& Task, FScheduleTask const& OtherTask,
 		FAppearanceProfile const& OtherProfile,
 		OptTimedProfile& LatestBefore, OptTimedProfile& EarliestAfter,
 		FTransformAssignment const* TransfoAssignment)
@@ -61,7 +62,7 @@ namespace Detail
 		}
 	}
 
-	void SetTransfoAssignmentDataDeps(FITwinSchedule const& Schedule,
+	inline void SetTransfoAssignmentDataDeps(FITwinSchedule const& Schedule,
 		ITwin::Timeline::FTaskDependenciesData& TaskDeps, TimedProfile const& Profile)
 	{
 		if (!Profile.TransfoAssignment)

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Timeline/TimelineTypes.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Timeline/TimelineTypes.h
@@ -16,6 +16,8 @@
 	#include <boost/functional/hash.hpp>
 #include <Compil/AfterNonUnrealIncludes.h>
 
+#include <algorithm>
+#include <vector>
 #include <unordered_set>
 #include <variant>
 
@@ -67,8 +69,18 @@ struct std::hash<FElementsGroup>
 public:
 	size_t operator()(FElementsGroup const& Elements) const
 	{
+		std::vector<ITwinElementID> SortedElements;
+		SortedElements.reserve(Elements.size());
+		for (ITwinElementID const& ElemID : Elements)
+			SortedElements.push_back(ElemID);
+		std::sort(SortedElements.begin(), SortedElements.end(),
+			[](ITwinElementID const& A, ITwinElementID const& B)
+			{
+				return A.value() < B.value();
+			});
+
 		size_t h = 0;
-		for (typename FElementsGroup::value_type const& ElemID : Elements)
+		for (ITwinElementID const& ElemID : SortedElements)
 			boost::hash_combine(h, ElemID.value());
 		return h;
 	}


### PR DESCRIPTION
## Summary

- Fix schedule timeline splitting for elements with multiple task-specific animation bindings.
- Reassign animation keys consistently across split elements and their animated parents.
- Preserve animation bindings when existing timelines are reused.
- Keep animation keys deterministic, sorted, and unique.
- Improve appearance-profile evaluation by checking only the relevant binding range.
- Improve schedule import handling for malformed entries missing `iModelId`.
- Add reusable-query shutdown support and preserve request validation results.
- Retune the iModel when glTF tuner animation rules change.
- Make element-group hashing deterministic.
- Add focused automated coverage for schedule-data handling and timeline-builder regressions.

## Purpose

Elements can be assigned to multiple schedule tasks with different visibility, color, and appearance states. For example, a generator may be hidden at the beginning of a schedule, shown during installation, assigned another appearance during testing, and changed to its operational appearance later.

During schedule import, timelines may be split when elements have different task bindings. Previously, splitting could leave elements or animated parents associated with outdated animation keys, or cause reused timelines to lose their animation bindings. This could make elements appear too early, remain visible when they should be hidden, or display the wrong appearance during playback.

This change keeps the element-to-timeline relationships consistent while preserving the bindings required to calculate the correct task-specific appearance throughout the 4D schedule.

The added tests cover timeline splitting, divergent task bindings, neutral appearance detection, empty timelines, deterministic element grouping, and related schedule-data handling.