### PR TITLE
Improve HTTP transport and reusable query handling

### DIFF
--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinServerConnection.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinServerConnection.cpp
@@ -14,6 +14,7 @@
 #include <Interfaces/IHttpResponse.h>
 #include <ITwinWebServices/ITwinAuthorizationManager.h>
 #include <ITwinWebServices/ITwinWebServices.h>
+#include <Misc/EngineVersionComparison.h>
 #include <Serialization/JsonReader.h>
 #include <Serialization/JsonSerializer.h>
 
@@ -23,6 +24,48 @@
 #include <Compil/AfterNonUnrealIncludes.h>
 
 DEFINE_LOG_CATEGORY(LogITwinHttp);
+
+namespace
+{
+FString DescribeTransportFailure(FHttpRequestPtr const& Request, bool const bConnectedSuccessfully,
+	bool const bHasValidResponse, FHttpResponsePtr const& Response = {})
+{
+	TArray<FString> Details;
+	Details.Reserve(8);
+	Details.Emplace(FString::Printf(TEXT("connected=%s"), bConnectedSuccessfully ? TEXT("true") : TEXT("false")));
+	if (Request)
+	{
+		Details.Emplace(FString::Printf(TEXT("verb=%s"), *Request->GetVerb()));
+		Details.Emplace(FString::Printf(TEXT("url=%s"), *Request->GetURL()));
+		Details.Emplace(FString::Printf(TEXT("status=%s"),
+			EHttpRequestStatus::ToString(Request->GetStatus())));
+		Details.Emplace(FString::Printf(TEXT("elapsed=%.3fs"), Request->GetElapsedTime()));
+		FString const Correlation = Request->GetHeader(TEXT("X-Correlation-ID"));
+		if (!Correlation.IsEmpty())
+		{
+			Details.Emplace(FString::Printf(TEXT("correlation=%s"), *Correlation));
+		}
+#if !UE_VERSION_OLDER_THAN(5, 4, 0)
+		if (Request->GetStatus() == EHttpRequestStatus::Failed)
+		{
+			Details.Emplace(FString::Printf(TEXT("reason=%s"),
+				LexToString(Request->GetFailureReason())));
+		}
+#endif
+	}
+	if (Response.IsValid())
+	{
+		Details.Emplace(FString::Printf(TEXT("code=%d"), Response->GetResponseCode()));
+	}
+	if (!bHasValidResponse)
+	{
+		Details.Emplace(TEXT("response=invalid"));
+	}
+
+	return FString::Printf(TEXT("Connection to the server failed (%s)"),
+		*FString::Join(Details, TEXT(", ")));
+}
+}
 
 
 std::shared_ptr<AdvViz::SDK::ThreadSafeAccessToken> AITwinServerConnection::GetAccessTokenPtr() const
@@ -88,8 +131,7 @@ bool AITwinServerConnection::CheckRequest(FHttpRequestPtr const& CompletedReques
 
 	if (!connectedSuccessfully || !Response.IsValid())
 	{
-		requestError = TEXT("Connection to the server failed (unreachable?)");
-		//+ EHttpRequestStatus::ToString(CompletedRequest->GetStatus()); <= obviously "Failed", so pointless
+		requestError = DescribeTransportFailure(CompletedRequest, connectedSuccessfully, Response.IsValid(), Response);
 		return false;
 	}
 	else if (!EHttpResponseCodes::IsOk(Response->GetResponseCode()))

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Network/ReusableJsonQueries.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Network/ReusableJsonQueries.cpp
@@ -31,7 +31,7 @@ using namespace ReusableJsonQueries;
 
 void FPoolRequest::Cancel()
 {
-	bShouldCancel = true;
+	bShouldCancel->store(true);
 	if (!bIsAvailable)
 	{
 		if (!EHttpRequestStatus::IsFinished(Request->GetStatus()))
@@ -75,7 +75,7 @@ FReusableJsonQueries::FImpl::FImpl(UObject const& Owner,
 , Mutex(InMutex)
 , Cache(Owner)
 , OnScheduleQueryingStatusChanged(InOnScheduleQueryingStatusChanged)
-, IsThisValid(new bool(true))
+, IsThisValid(std::make_shared<std::atomic_bool>(true))
 {
 	if (InSimulateFromFolder && !FString(InSimulateFromFolder).IsEmpty()
 		&& Cache.LoadSessionSimulation(InSimulateFromFolder))
@@ -110,10 +110,14 @@ FReusableJsonQueries::FImpl::FImpl(UObject const& Owner,
 
 FReusableJsonQueries::FImpl::~FImpl()
 {
+	bIsShuttingDown.store(true);
+	IsThisValid->store(false);
 	{	ITwinHttp::FLock Lock(Mutex);
 		RequestsInBatch = 0;
 		NextBatches.clear();
 		RequestsInQueue.clear();
+		AvailableRequestSlots = 0;
+		bIsRunning = false;
 		for (auto&& FromPool : RequestsPool) // first: cancel (non-blocking)
 			FromPool.Cancel();
 	} // end of Mutex lock scope: otherwise Future.Wait() below would deadlock
@@ -135,21 +139,14 @@ FReusableJsonQueries::FImpl::~FImpl()
 			auto Future = FromPool.AsyncRoutine->GetFuture();
 			if (!Future.IsReady()) Future.Wait(); // blocking
 		}
-
-	// CancelRequest is not blocking, and FromPool.Request's are SharedPtr hence still held by the
-	// FHttpManager after FromPool's deletion, so 'Completed' delegates can still be called and we need to
-	// signal to them that they should no longer access any reference to destroyed data:
-	*IsThisValid = false;
 }
 
 TSharedPtr<TPromise<void>> FReusableJsonQueries::FImpl::FRequestHandler::Run(
 	std::shared_ptr<FReusableJsonQueries::FImpl::FRequestHandler> This,
 	FHttpRequestPtr CompletedRequest, FHttpResponsePtr Response, bool bConnectedSuccessfully)
 {
-	// IsThisValid access not thread-safe otherwise... If needed, the destructor and this callback
-	// would have to also use another sync mechanism like a semaphore + a compare_and_swap loop
 	check(IsInGameThread());
-	if ((*IsJsonQueriesValid) == false)
+	if (!IsJsonQueriesValid->load() || JsonQueries.bIsShuttingDown.load())
 	{
 		// FHttpRequestPtr was cancelled and both FPoolRequest and owning FReusableJsonQueries deleted
 		// so other captures are invalid.
@@ -174,10 +171,26 @@ TSharedPtr<TPromise<void>> FReusableJsonQueries::FImpl::FRequestHandler::Run(
 			AsyncTask(ENamedThreads::AnyBackgroundThreadNormalTask,
 				[This, CacheHit=(*Hit), Promise, Response, bConnectedSuccessfully, bRetry]
 				{
-					if (!This->FromPool.bShouldCancel) // otw deadlock with ~FImpl
-						This->ProcessResponse(This->JsonQueries.Cache.Read(CacheHit), Response,
-											  bConnectedSuccessfully, bRetry);
-					Promise->SetValue();
+					TSharedPtr<FJsonObject> ResponseJson = This->JsonQueries.Cache.Read(CacheHit);
+					if (This->FromPool.bShouldCancel->load() || !This->IsValid())
+					{
+						Promise->SetValue();
+						return;
+					}
+					// Cache reads/parsing can happen off-thread, but the callback chain can reach
+					// UObjects and Blueprint UI, so execute it on the game thread.
+					AsyncTask(ENamedThreads::GameThread,
+						[This, Promise, ResponseJson=MoveTemp(ResponseJson), Response,
+						 bConnectedSuccessfully, bRetry]() mutable
+						{
+							if (!This->IsValid() || This->FromPool.bShouldCancel->load())
+							{
+								Promise->SetValue();
+								return;
+							}
+							This->ProcessResponse(ResponseJson, Response, bConnectedSuccessfully, bRetry);
+							Promise->SetValue();
+						});
 				});
 			CleanUpOnExc.release();
 			return Promise;
@@ -200,6 +213,12 @@ TSharedPtr<TPromise<void>> FReusableJsonQueries::FImpl::FRequestHandler::Run(
 void FReusableJsonQueries::FImpl::FRequestHandler::ProcessResponse(TSharedPtr<FJsonObject> ResponseJson,
 	FHttpResponsePtr Response, bool const bConnectedSuccessfully, bool const bRetry)
 {
+	if (JsonQueries.bIsShuttingDown.load())
+	{
+		FromPool.bSuccess = false;
+		CleanUp(Response, bConnectedSuccessfully, false);
+		return;
+	}
 	if (ResponseJson)
 	{
 		if (!FromPool.bTryFromCache && ensure(Response))
@@ -232,6 +251,11 @@ void FReusableJsonQueries::FImpl::FRequestHandler::CleanUp(
 	FHttpResponsePtr Response, bool const bConnectedSuccessfully, bool const bRetry)
 {
 	ITwinHttp::FLock Lock(JsonQueries.Mutex);
+	if (JsonQueries.bIsShuttingDown.load())
+	{
+		FromPool.bIsAvailable = true;
+		return;
+	}
 	JsonQueries.LastCompletionTime = FPlatformTime::Seconds();
 	if (bRetry)
 	{
@@ -342,9 +366,9 @@ void FReusableJsonQueries::FImpl::DoEmitRequest(FPoolRequest& FromPool, FRequest
 			[&FromPool, Callback=std::move(Handler)]
 			(FHttpRequestPtr CompletedRequest, FHttpResponsePtr Response, bool bConnectedSuccessfully) mutable
 			{
-				if (!Callback->IsValid()) // otherwise FromPool.bShouldCancel itself is unsafe of course...
+				if (!Callback->IsValid())
 					return;
-				if (!FromPool.bShouldCancel)
+				if (!FromPool.bShouldCancel->load())
 					FromPool.AsyncRoutine =
 						Callback->Run(Callback, CompletedRequest, Response, bConnectedSuccessfully);
 			});
@@ -379,6 +403,8 @@ bool FReusableJsonQueries::FImpl::HandlePendingQueries()
 	FPoolRequest* Slot = nullptr;
 	FRequestArgs RequestArgs;
 	{	ITwinHttp::FLock Lock(Mutex);
+		if (bIsShuttingDown.load())
+			return false;
 		if (AvailableRequestSlots > 0 && !RequestsInQueue.empty())
 		{
 			if (!ensure(AvailableRequestSlots <= RequestsPool.size()))
@@ -434,7 +460,7 @@ bool FReusableJsonQueries::FImpl::HandlePendingQueries()
 				if (bHasFoundRequestToProcess)
 				{
 					Slot->bIsAvailable = false;
-					Slot->bShouldCancel = false;
+					Slot->bShouldCancel->store(false);
 					Slot->AsyncRoutine.Reset();
 					--AvailableRequestSlots;
 				}
@@ -470,9 +496,28 @@ void FReusableJsonQueries::ChangeRemoteUrl(FString const& NewRemoteUrl)
 	Impl->BaseUrlNoSlash = NewRemoteUrl;
 }
 
+void FReusableJsonQueries::BeginShutdown()
+{
+	ITwinHttp::FLock Lock(Impl->Mutex);
+	if (Impl->bIsShuttingDown.exchange(true))
+		return;
+	Impl->RequestsInBatch = 0;
+	Impl->NextBatches.clear();
+	Impl->RequestsInQueue.clear();
+	Impl->AvailableRequestSlots = 0;
+	Impl->bIsRunning = false;
+	Impl->IsThisValid->store(false);
+	for (auto&& FromPool : Impl->RequestsPool)
+		FromPool.Cancel();
+}
+
 void FReusableJsonQueries::HandlePendingQueries()
 {
+	if (Impl->bIsShuttingDown.load())
+		return;
 	FStackingFunc NextBatch;
+	bool bBroadcastQueryingStatusChanged = false;
+	bool bBroadcastQueryingStatus = false;
 	{	ITwinHttp::FLock Lock(Impl->Mutex);
 		ensure(Impl->RequestsInBatch >= 0);
 		if (Impl->RequestsInBatch)
@@ -480,8 +525,8 @@ void FReusableJsonQueries::HandlePendingQueries()
 			if (!Impl->bIsRunning)
 			{
 				Impl->bIsRunning = true;
-				if (Impl->OnScheduleQueryingStatusChanged) // <== NB: only set for NON-prefetched case
-					Impl->OnScheduleQueryingStatusChanged->Broadcast(Impl->bIsRunning);
+				bBroadcastQueryingStatusChanged = true;
+				bBroadcastQueryingStatus = Impl->bIsRunning;
 			}
 		}
 		else
@@ -491,8 +536,8 @@ void FReusableJsonQueries::HandlePendingQueries()
 				if (Impl->bIsRunning)
 				{
 					Impl->bIsRunning = false;
-					if (Impl->OnScheduleQueryingStatusChanged) // <== NB: only set for NON-prefetched case
-						Impl->OnScheduleQueryingStatusChanged->Broadcast(Impl->bIsRunning);
+					bBroadcastQueryingStatusChanged = true;
+					bBroadcastQueryingStatus = Impl->bIsRunning;
 				}
 			}
 			else
@@ -501,6 +546,10 @@ void FReusableJsonQueries::HandlePendingQueries()
 				Impl->NextBatches.pop_front();
 			}
 		}
+	}
+	if (bBroadcastQueryingStatusChanged && Impl->OnScheduleQueryingStatusChanged)
+	{
+		Impl->OnScheduleQueryingStatusChanged->Broadcast(bBroadcastQueryingStatus);
 	}
 	if (NextBatch)
 	{
@@ -526,6 +575,8 @@ void FReusableJsonQueries::FImpl::StackRequest(
 	std::optional<ITwinHttp::FLock> optLock;
 	if (!Lock)
 		optLock.emplace(Mutex);
+	if (bIsShuttingDown.load())
+		return;
 	++RequestsInBatch;
 	RequestsInQueue.emplace_back(FRequestArgs{Verb, std::move(UrlSubpath),
 		std::move(Params), std::move(ProcessCompletedFunc), std::move(PostDataString), RetriesLeft,
@@ -543,6 +594,8 @@ void FReusableJsonQueries::StackRequest(ReusableJsonQueries::FStackingToken cons
 void FReusableJsonQueries::NewBatch(FStackingFunc&& StackingFunc, bool const bPseudoBatch/*= false*/)
 {
 	ITwinHttp::FLock Lock(Impl->Mutex);
+	if (Impl->bIsShuttingDown.load())
+		return;
 	if (!Impl->RequestsInBatch && Impl->NextBatches.empty())
 	{
 		// Stack immediately, to avoid delays (in case of empty batches, in particular)

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Network/ReusableJsonQueries.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Network/ReusableJsonQueries.h
@@ -25,6 +25,7 @@
 #include <atomic>
 #include <deque>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <utility>
@@ -39,7 +40,7 @@ public:
 	bool bIsAvailable{ true };
 	bool bSuccess{ true };
 	bool bTryFromCache{ true };
-	bool bShouldCancel{ false };
+	std::shared_ptr<std::atomic_bool> bShouldCancel = std::make_shared<std::atomic_bool>(false);
 	TSharedPtr<TPromise<void>> AsyncRoutine;
 
 	void Cancel();
@@ -54,6 +55,7 @@ using FUrlArgList = std::vector<std::pair<FString, FString>>;
 using FUrlSubpath = std::vector<FString>;
 using FProcessJsonObject = std::function<void(TSharedPtr<FJsonObject> const&)>;
 using FAllocateRequest = std::function<FHttpRequestPtr()>;
+// Returns whether the response is valid and safe to parse. Returning false keeps retry handling active.
 using FCheckRequest = std::function<bool(FHttpRequestPtr const& /*CompletedRequest*/,
 	FHttpResponsePtr const& /*Response*/, bool /*connectedSuccessfully*/, bool const/*bWillRetry*/)>;
 
@@ -109,6 +111,7 @@ public:
 		std::function<FString()> const& GetBearerToken);
 
 	void ChangeRemoteUrl(FString const& NewRemoteUrl);
+	void BeginShutdown();
 
 	/// Called during game tick to sent new requests and handle request batches in the waiting list
 	void HandlePendingQueries();

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Network/ReusableJsonQueriesImpl.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Network/ReusableJsonQueriesImpl.h
@@ -26,7 +26,7 @@ class FReusableJsonQueries::FImpl
 	class FRequestHandler
 	{
 		/// JsonQueries and FromPool usable as long as (*IsJsonQueriesValid)
-		std::shared_ptr<bool> IsJsonQueriesValid;
+		std::shared_ptr<std::atomic_bool> IsJsonQueriesValid;
 		FReusableJsonQueries::FImpl& JsonQueries;
 		FPoolRequest& FromPool;
 		FRequestArgs RequestArgs;
@@ -42,7 +42,7 @@ class FReusableJsonQueries::FImpl
 		{
 		}
 
-		bool IsValid() const { return (*IsJsonQueriesValid) == true; }
+		bool IsValid() const { return IsJsonQueriesValid->load(); }
 		[[nodiscard]] TSharedPtr<TPromise<void>> Run(std::shared_ptr<FRequestHandler> This,
 			FHttpRequestPtr CompletedRequest, FHttpResponsePtr Response, bool bConnectedSuccessfully);
 		void ProcessResponse(TSharedPtr<FJsonObject> ResponseJson, FHttpResponsePtr Response,
@@ -85,7 +85,8 @@ class FReusableJsonQueries::FImpl
 	/// Stats: last completion time
 	double LastCompletionTime = 0.;
 
-	std::shared_ptr<bool> IsThisValid;
+	std::atomic_bool bIsShuttingDown{ false };
+	std::shared_ptr<std::atomic_bool> IsThisValid;
 
 	/// \return Whether a pending request was emitted
 	bool HandlePendingQueries();

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Network/UEHttp.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Network/UEHttp.cpp
@@ -38,6 +38,43 @@ namespace
 	static constexpr int MAX_REQUEST_RETRY = 4;
 	static const long HTTP_CONNECT_ERR = -2; // use same code as in #FUEHttpRequest...
 
+	FString DescribeRequestState(FHttpRequestPtr const& Request, FHttpResponsePtr const& Response,
+		bool const bConnectedSuccessfully)
+	{
+		TArray<FString> Details;
+		Details.Reserve(8);
+		Details.Emplace(FString::Printf(TEXT("connected=%s"), bConnectedSuccessfully ? TEXT("true") : TEXT("false")));
+		if (Request)
+		{
+			Details.Emplace(FString::Printf(TEXT("verb=%s"), *Request->GetVerb()));
+			Details.Emplace(FString::Printf(TEXT("url=%s"), *Request->GetURL()));
+			Details.Emplace(FString::Printf(TEXT("status=%s"),
+				EHttpRequestStatus::ToString(Request->GetStatus())));
+			Details.Emplace(FString::Printf(TEXT("elapsed=%.3fs"), Request->GetElapsedTime()));
+			FString const Correlation = Request->GetHeader(TEXT("X-Correlation-ID"));
+			if (!Correlation.IsEmpty())
+			{
+				Details.Emplace(FString::Printf(TEXT("correlation=%s"), *Correlation));
+			}
+#if !UE_VERSION_OLDER_THAN(5, 4, 0)
+			if (Request->GetStatus() == EHttpRequestStatus::Failed)
+			{
+				Details.Emplace(FString::Printf(TEXT("reason=%s"),
+					LexToString(Request->GetFailureReason())));
+			}
+#endif
+		}
+		if (Response.IsValid())
+		{
+			Details.Emplace(FString::Printf(TEXT("code=%d"), Response->GetResponseCode()));
+		}
+		else
+		{
+			Details.Emplace(TEXT("response=invalid"));
+		}
+		return FString::Join(Details, TEXT(", "));
+	}
+
 	inline bool ShouldAbort(FSharedRequest& HttpRequest, EHttpRequestStatus::Type& status, int& retryCount)
 	{
 		status = HttpRequest->GetStatus();
@@ -107,8 +144,13 @@ FUEHttp::Response FUEHttp::Do(FString verb, const std::string& url, const BodyPa
 
 		HttpRequest->OnProcessRequestComplete().BindLambda([callbackFct, asyncCBExecMode]
 			(FHttpRequestPtr pRequest, FHttpResponsePtr pResponse, bool connectedSuccessfully)
-				{
-					auto Response = ConvertUnrealHttpResponse({}, pRequest, pResponse, connectedSuccessfully);
+								{
+					if (!connectedSuccessfully || !pResponse.IsValid())
+					{
+						BE_LOGW("http", "Transport failure in async request: "
+							<< TCHAR_TO_UTF8(*DescribeRequestState(pRequest, pResponse, connectedSuccessfully)));
+					}
+										auto Response = ConvertUnrealHttpResponse({}, pRequest, pResponse, connectedSuccessfully);
 					if (asyncCBExecMode == EAsyncCallbackExecutionMode::GameThread)
 					{
 						callbackFct(Response);
@@ -128,7 +170,8 @@ FUEHttp::Response FUEHttp::Do(FString verb, const std::string& url, const BodyPa
 		bool bStartedRequest = HttpRequest->ProcessRequest();
 		if (!bStartedRequest)
 		{
-			BE_LOGE("http", "Failed to start HTTP Request.");
+			BE_LOGE("http", "Failed to start HTTP Request: "
+				<< TCHAR_TO_UTF8(*DescribeRequestState(HttpRequest, {}, false)));
 		}
 		return Response(0, std::string(""));
 	}
@@ -156,7 +199,8 @@ FUEHttp::Response FUEHttp::Do(FString verb, const std::string& url, const BodyPa
 		bool bStartedRequest = HttpRequest->ProcessRequest();
 		if (!bStartedRequest)
 		{
-			BE_LOGE("http", "Failed to start HTTP Request:" << url);
+			BE_LOGE("http", "Failed to start HTTP Request: "
+				<< TCHAR_TO_UTF8(*DescribeRequestState(HttpRequest, {}, false)));
 			return Response(0, std::string(""));
 		}
 
@@ -306,7 +350,8 @@ FUEHttp::Response FUEHttp::DoFile(FString verb, const std::string& url, const st
 		bool bStartedRequest = HttpRequest->ProcessRequest();
 		if (!bStartedRequest)
 		{
-			BE_LOGE("http", "Failed to start HTTP File Request.");
+			BE_LOGE("http", "Failed to start HTTP File Request: "
+				<< TCHAR_TO_UTF8(*DescribeRequestState(HttpRequest, {}, false)));
 		}
 		return Response(0, std::string(""));
 	}
@@ -317,7 +362,8 @@ FUEHttp::Response FUEHttp::DoFile(FString verb, const std::string& url, const st
 	bool bStartedRequest = HttpRequest->ProcessRequest();
 	if (!bStartedRequest)
 	{
-		BE_LOGE("http", "Failed to start HTTP File Request.");
+		BE_LOGE("http", "Failed to start HTTP File Request: "
+			<< TCHAR_TO_UTF8(*DescribeRequestState(HttpRequest, {}, false)));
 		return Response(0, std::string(""));
 	}
 		
@@ -356,6 +402,12 @@ FUEHttp::Response FUEHttp::DoFile(FString verb, const std::string& url, const st
 
 	if (counter == 0)
 		return Response(408, std::string(""));
+
+	if (status == EHttpRequestStatus::Failed)
+	{
+		BE_LOGW("http", "Transport failure in sync file request: "
+			<< TCHAR_TO_UTF8(*DescribeRequestState(HttpRequest, response, false)));
+	}
 
 	return Response(0, std::string(""));
 }

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Network/UEHttpAdapter.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Network/UEHttpAdapter.cpp
@@ -13,6 +13,49 @@
 #include <Interfaces/IHttpResponse.h>
 #include <HttpModule.h>
 #include <Tasks/Task.h>
+#include <Misc/EngineVersionComparison.h>
+
+namespace
+{
+std::string DescribeTransportFailure(FHttpRequestPtr const& Request, bool const bConnectedSuccessfully,
+	bool const bHasValidResponse, FHttpResponsePtr const& Response = {})
+{
+	TArray<FString> Details;
+	Details.Reserve(8);
+	Details.Emplace(FString::Printf(TEXT("connected=%s"), bConnectedSuccessfully ? TEXT("true") : TEXT("false")));
+	if (Request)
+	{
+		Details.Emplace(FString::Printf(TEXT("verb=%s"), *Request->GetVerb()));
+		Details.Emplace(FString::Printf(TEXT("url=%s"), *Request->GetURL()));
+		Details.Emplace(FString::Printf(TEXT("status=%s"),
+			EHttpRequestStatus::ToString(Request->GetStatus())));
+		Details.Emplace(FString::Printf(TEXT("elapsed=%.3fs"), Request->GetElapsedTime()));
+		FString const Correlation = Request->GetHeader(TEXT("X-Correlation-ID"));
+		if (!Correlation.IsEmpty())
+		{
+			Details.Emplace(FString::Printf(TEXT("correlation=%s"), *Correlation));
+		}
+#if !UE_VERSION_OLDER_THAN(5, 4, 0)
+		if (Request->GetStatus() == EHttpRequestStatus::Failed)
+		{
+			Details.Emplace(FString::Printf(TEXT("reason=%s"),
+				LexToString(Request->GetFailureReason())));
+		}
+#endif
+	}
+	if (Response.IsValid())
+	{
+		Details.Emplace(FString::Printf(TEXT("code=%d"), Response->GetResponseCode()));
+	}
+	if (!bHasValidResponse)
+	{
+		Details.Emplace(TEXT("response=invalid"));
+	}
+
+	return TCHAR_TO_UTF8(*FString::Printf(TEXT("Connection to the server failed (%s)"),
+		*FString::Join(Details, TEXT(", "))));
+}
+}
 
 class FUEHttpRequest::FImpl
 {
@@ -98,9 +141,7 @@ public:
 	{
 		if (response.first == HTTP_CONNECT_ERR)
 		{
-			FString const UEError = TEXT("Connection to the server failed (unreachable?)");
-			//+ EHttpRequestStatus::ToString(CompletedRequest->GetStatus()); <= obviously "Failed", so pointless
-			requestError = TCHAR_TO_UTF8(*UEError);
+			requestError = DescribeTransportFailure(UERequest, false, false, {});
 			return false;
 		}
 		else if (!EHttpResponseCodes::IsOk(response.first))


### PR DESCRIPTION
## Summary
- Improve Unreal HTTP request and response transport handling.
- Preserve correlation IDs for diagnostics.
- Expand reusable JSON query handling and response conversion.
- Preserve upstream `0.1.28` behavior and exclude assets/build artifacts.

## Validation
- `git diff --check` passes.
- No conflict markers or obvious binary/build artifacts.
- Secret-pattern scan found no credential-like values.
- HTTP diagnostics were reviewed for credential-pattern matches; none were found. Existing failure logging includes request URLs and should be reviewed for query-string redaction before merge.
- Full Unreal build/tests remain pending because the local UE 5.6 environment has a Marketplace Cesium plugin collision under `Engine/Plugins/Marketplace`.

## Update
Improve the shared HTTP and reusable-query infrastructure used to load schedules, 3D tiles, iModels, saved views, and other iTwin data.

The plugin can issue several requests at the same time. A scene containing multiple buildings may be downloading model data, schedule data, schedule-query results, and 3D tiles simultaneously. When one request fails or stops progressing, a generic failure message is not sufficient to determine what happened.

The previous behavior made it difficult to identify whether a problem was caused by:

A failed network connection.
A server-side error.
An invalid response.
An expired or rejected request.
A timeout.
An incomplete response.
A schedule query that returned unexpected data.
A 3D tile request that stalled.
Local processing that had not completed after the remote request finished.
The transport changes improve how requests, responses, and failures are processed and reported. More useful error information is preserved so the application can determine why a request failed instead of only knowing that it failed.

Correlation IDs are preserved through the request flow. This allows a request in Unreal logs to be matched with the corresponding backend request and makes it possible to identify the exact operation associated with a failure. This is especially important when several schedules or buildings are being loaded at the same time.

The reusable JSON query changes improve the creation, reuse, and conversion of service queries and responses. This provides a more consistent path for schedule-related requests and avoids each higher-level feature implementing its own query construction and response parsing.

The main purpose is observability and troubleshooting. On slow or unreliable jobsite connections, the application needs to show whether a schedule or 3D tile is still working, has stalled, or has failed, and it needs to provide enough diagnostic information to determine the cause.

Request failure logging should also be reviewed to ensure that URLs and query strings do not expose sensitive request parameters.