### PR TITLE
Expand iTwin web-services API support

### DIFF
--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinIModelInternals.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinIModelInternals.h
@@ -109,7 +109,7 @@ public:
 
 	enum class E4DScheduleStatus
 	{
-		Unknown, Loading, Finished, NoneOrEmpty
+		Unknown, Loading, Finished, Failed, NoneOrEmpty
 	};
 	void Update4DScheduleDownloadStatus(E4DScheduleStatus Sched4DStatus, double PercentComplete = 0.);
 	bool AreSynchro4DSchedulesMetadataLoadedOrCancelled() const;

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinWebServices/ITwinWebServices.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinWebServices/ITwinWebServices.cpp
@@ -20,9 +20,13 @@
 #include <Network/UEHttpAdapter.h>
 
 
+#include <Dom/JsonObject.h>
+#include <Dom/JsonValue.h>
 #include <Kismet/GameplayStatics.h>
 
 #include <Engine/World.h>
+#include <Serialization/JsonReader.h>
+#include <Serialization/JsonSerializer.h>
 
 #include <Compil/BeforeNonUnrealIncludes.h>
 #	include <Core/ITwinAPI/ITwinRequestTypes.h>
@@ -42,6 +46,26 @@ namespace ITwin
 namespace
 {
 	static thread_local UITwinWebServices* WorkingInstance = nullptr;
+
+	struct FProcessingConnectionInfo
+	{
+		FString Id;
+		FString DisplayName;
+		FString Type;
+		FString LastRunUrl;
+	};
+
+	struct FProcessingStatusRequestState
+	{
+		std::mutex Mutex;
+		FString IModelId;
+		bool bSawConnection = false;
+		bool bFinalized = false;
+		bool bHasBestStatus = false;
+		int32 PendingRunRequests = 0;
+		int32 CompletedRunRequests = 0;
+		FIModelProcessingStatus BestStatus;
+	};
 
 	struct [[nodiscard]] ScopedWorkingWebServices
 	{
@@ -71,6 +95,202 @@ namespace
 	{
 		BE_ASSERT(IsEncodingIndifferent(StrId));
 		return TCHAR_TO_ANSI(*StrId);
+	}
+
+	inline bool ParseJsonObject(std::string const& Response, TSharedPtr<FJsonObject>& OutObject)
+	{
+		auto Reader = TJsonReaderFactory<TCHAR>::Create(UTF8_TO_TCHAR(Response.c_str()));
+		return FJsonSerializer::Deserialize(Reader, OutObject) && OutObject.IsValid();
+	}
+
+	inline FString GetOptionalStringField(TSharedPtr<FJsonObject> const& JsonObject, TCHAR const* FieldName)
+	{
+		FString Value;
+		if (JsonObject.IsValid() && JsonObject->TryGetStringField(FieldName, Value))
+		{
+			return Value;
+		}
+		return {};
+	}
+
+	inline FString DeriveConnectionType(FString const& LastRunUrl)
+	{
+		const FString LowerUrl = LastRunUrl.ToLower();
+		if (LowerUrl.Contains(TEXT("/manifestconnections/")))
+		{
+			return TEXT("manifest");
+		}
+		if (LowerUrl.Contains(TEXT("/storageconnections/")))
+		{
+			return TEXT("storage");
+		}
+		return TEXT("connection");
+	}
+
+	inline bool IsSynchronizationRunningState(FString const& RunState)
+	{
+		const FString LowerState = RunState.ToLower();
+		return LowerState == TEXT("queued")
+			|| LowerState == TEXT("waitingtoexecute")
+			|| LowerState == TEXT("waitingtoretry")
+			|| LowerState == TEXT("executing")
+			|| LowerState == TEXT("finalizing");
+	}
+
+	inline FString DeriveProcessingStatus(FString const& RunState, FString const& RunResult,
+		bool bHasRun, bool bHasConnection)
+	{
+		if (!bHasConnection)
+		{
+			return TEXT("not configured");
+		}
+		if (!bHasRun)
+		{
+			return TEXT("not started");
+		}
+		if (IsSynchronizationRunningState(RunState))
+		{
+			return TEXT("synchronization running");
+		}
+
+		const FString LowerResult = RunResult.ToLower();
+		if (LowerResult == TEXT("partialsuccess"))
+		{
+			return TEXT("complete with warnings");
+		}
+		if (LowerResult == TEXT("error") || LowerResult == TEXT("failed") || LowerResult == TEXT("failure"))
+		{
+			return TEXT("failed");
+		}
+		if (LowerResult == TEXT("timedout") || LowerResult == TEXT("timeout"))
+		{
+			return TEXT("timed out");
+		}
+		if (LowerResult == TEXT("canceled") || LowerResult == TEXT("cancelled"))
+		{
+			return TEXT("cancelled");
+		}
+		if (LowerResult == TEXT("success") || LowerResult == TEXT("succeeded"))
+		{
+			return TEXT("complete");
+		}
+
+		const FString LowerState = RunState.ToLower();
+		if (LowerState == TEXT("completed") || LowerState == TEXT("finished"))
+		{
+			return TEXT("complete");
+		}
+		return TEXT("unknown");
+	}
+
+	inline int32 GetProcessingStatusRank(FIModelProcessingStatus const& Status)
+	{
+		if (Status.bSynchronizationRunning)
+		{
+			return 5;
+		}
+
+		const FString LowerStatus = Status.ProcessingStatus.ToLower();
+		if (LowerStatus == TEXT("failed") || LowerStatus == TEXT("timed out")
+			|| LowerStatus == TEXT("cancelled"))
+		{
+			return 4;
+		}
+		if (LowerStatus == TEXT("complete with warnings"))
+		{
+			return 3;
+		}
+		if (LowerStatus == TEXT("not started"))
+		{
+			return 2;
+		}
+		if (LowerStatus == TEXT("complete"))
+		{
+			return 1;
+		}
+		return 0;
+	}
+
+	inline void UpdateBestProcessingStatus(FProcessingStatusRequestState& State,
+		FIModelProcessingStatus const& Candidate)
+	{
+		if (!State.bHasBestStatus)
+		{
+			State.BestStatus = Candidate;
+			State.bHasBestStatus = true;
+			return;
+		}
+
+		const int32 CandidateRank = GetProcessingStatusRank(Candidate);
+		const int32 CurrentRank = GetProcessingStatusRank(State.BestStatus);
+		if (CandidateRank > CurrentRank
+			|| (CandidateRank == CurrentRank
+				&& Candidate.StartDateTime > State.BestStatus.StartDateTime))
+		{
+			State.BestStatus = Candidate;
+		}
+	}
+
+	inline FProcessingConnectionInfo ParseProcessingConnection(TSharedPtr<FJsonObject> const& ConnectionObject)
+	{
+		FProcessingConnectionInfo Connection;
+		Connection.Id = GetOptionalStringField(ConnectionObject, TEXT("id"));
+		Connection.DisplayName = GetOptionalStringField(ConnectionObject, TEXT("displayName"));
+
+		const TSharedPtr<FJsonObject>* LinksObject = nullptr;
+		if (ConnectionObject.IsValid()
+			&& ConnectionObject->TryGetObjectField(TEXT("_links"), LinksObject)
+			&& LinksObject && (*LinksObject).IsValid())
+		{
+			const TSharedPtr<FJsonObject>* LastRunObject = nullptr;
+			if ((*LinksObject)->TryGetObjectField(TEXT("lastRun"), LastRunObject)
+				&& LastRunObject && (*LastRunObject).IsValid())
+			{
+				Connection.LastRunUrl = GetOptionalStringField(*LastRunObject, TEXT("href"));
+			}
+		}
+
+		Connection.Type = DeriveConnectionType(Connection.LastRunUrl);
+		return Connection;
+	}
+
+	inline FIModelProcessingStatus MakeFallbackProcessingStatus(FString const& IModelId, bool bHasConnection)
+	{
+		FIModelProcessingStatus Status;
+		Status.IModelId = IModelId;
+		Status.ProcessingStatus = DeriveProcessingStatus({}, {}, false, bHasConnection);
+		return Status;
+	}
+
+	inline FIModelProcessingStatus MakeConnectionProcessingStatus(FString const& IModelId,
+		FProcessingConnectionInfo const& Connection)
+	{
+		FIModelProcessingStatus Status;
+		Status.IModelId = IModelId;
+		Status.ProcessingStatus = DeriveProcessingStatus({}, {}, false, true);
+		Status.ConnectionId = Connection.Id;
+		Status.ConnectionType = Connection.Type;
+		Status.ConnectionDisplayName = Connection.DisplayName;
+		return Status;
+	}
+
+	inline FIModelProcessingStatus MakeRunProcessingStatus(FString const& IModelId,
+		FProcessingConnectionInfo const& Connection, TSharedPtr<FJsonObject> const& RunObject)
+	{
+		FIModelProcessingStatus Status;
+		Status.IModelId = IModelId;
+		Status.ConnectionId = Connection.Id;
+		Status.ConnectionType = Connection.Type;
+		Status.ConnectionDisplayName = Connection.DisplayName;
+		Status.RunId = GetOptionalStringField(RunObject, TEXT("id"));
+		Status.RunState = GetOptionalStringField(RunObject, TEXT("state"));
+		Status.RunResult = GetOptionalStringField(RunObject, TEXT("result"));
+		Status.RunPhase = GetOptionalStringField(RunObject, TEXT("phase"));
+		Status.StartDateTime = GetOptionalStringField(RunObject, TEXT("startDateTime"));
+		Status.EndDateTime = GetOptionalStringField(RunObject, TEXT("endDateTime"));
+		Status.bSynchronizationRunning = IsSynchronizationRunningState(Status.RunState);
+		Status.ProcessingStatus = DeriveProcessingStatus(Status.RunState, Status.RunResult, true, true);
+		return Status;
 	}
 }
 
@@ -1516,6 +1736,169 @@ void UITwinWebServices::GetiTwins()
 void UITwinWebServices::GetiTwiniModels(FString ITwinId)
 {
 	DoRequest([this, ITwinId]() { Impl->GetITwinIModels(IDToStdString(ITwinId)); });
+}
+
+void UITwinWebServices::GetIModelProcessingStatus(FString IModelId)
+{
+	DoRequest([this, IModelId]()
+	{
+		auto RequestState = MakeShared<FProcessingStatusRequestState>();
+		RequestState->IModelId = IModelId;
+
+		TWeakObjectPtr<UITwinWebServices> WeakThis(this);
+		const auto Finalize =
+			[WeakThis, RequestState](bool bSuccess)
+		{
+			FIModelProcessingStatus Status;
+			{
+				std::lock_guard Lock(RequestState->Mutex);
+				if (RequestState->bFinalized)
+				{
+					return;
+				}
+				RequestState->bFinalized = true;
+				Status = RequestState->bHasBestStatus
+					? RequestState->BestStatus
+					: MakeFallbackProcessingStatus(RequestState->IModelId, RequestState->bSawConnection);
+			}
+
+			if (UITwinWebServices* StrongThis = WeakThis.Get())
+			{
+				StrongThis->OnGetIModelProcessingStatusComplete.Broadcast(bSuccess, Status);
+				if (StrongThis->Impl->observer_)
+				{
+					StrongThis->Impl->observer_->OnIModelProcessingStatusRetrieved(bSuccess, Status);
+				}
+			}
+		};
+
+		AdvViz::SDK::ITwinAPIRequestInfo ConnectionsRequestInfo{
+			"GetIModelProcessingStatus",
+			AdvViz::SDK::EVerb::Get,
+			"/synchronization/imodels/connections?imodelId=" + IDToStdString(IModelId),
+			"application/vnd.bentley.itwin-platform.v1+json"
+		};
+		ConnectionsRequestInfo.CustomHeaders.emplace("Prefer", "return=representation");
+
+		Impl->RunCustomRequest(ConnectionsRequestInfo,
+			[this, IModelId, RequestState, Finalize](long HttpStatus, std::string const& Response,
+				AdvViz::SDK::RequestID const&, std::string& StrError) mutable -> bool
+		{
+			TSharedPtr<FJsonObject> JsonObject;
+			if (HttpStatus < 200 || HttpStatus >= 300 || !ParseJsonObject(Response, JsonObject))
+			{
+				StrError = "Failed to parse synchronization connections response.";
+				Finalize(false);
+				return false;
+			}
+
+			const TArray<TSharedPtr<FJsonValue>>* ConnectionsArray = nullptr;
+			if (!JsonObject->TryGetArrayField(TEXT("connections"), ConnectionsArray) || !ConnectionsArray)
+			{
+				StrError = "Synchronization connections response is missing 'connections'.";
+				Finalize(false);
+				return false;
+			}
+
+			TArray<FProcessingConnectionInfo> ConnectionsWithRuns;
+			{
+				std::lock_guard Lock(RequestState->Mutex);
+				RequestState->bSawConnection = !ConnectionsArray->IsEmpty();
+			}
+
+			for (TSharedPtr<FJsonValue> const& ConnectionValue : *ConnectionsArray)
+			{
+				const TSharedPtr<FJsonObject> ConnectionObject = ConnectionValue ? ConnectionValue->AsObject() : nullptr;
+				if (!ConnectionObject.IsValid())
+				{
+					continue;
+				}
+
+				FProcessingConnectionInfo const Connection = ParseProcessingConnection(ConnectionObject);
+				if (Connection.Id.IsEmpty())
+				{
+					continue;
+				}
+
+				if (Connection.LastRunUrl.IsEmpty())
+				{
+					std::lock_guard Lock(RequestState->Mutex);
+					UpdateBestProcessingStatus(*RequestState, MakeConnectionProcessingStatus(IModelId, Connection));
+				}
+				else
+				{
+					ConnectionsWithRuns.Add(Connection);
+				}
+			}
+
+			if (ConnectionsWithRuns.IsEmpty())
+			{
+				Finalize(true);
+				return true;
+			}
+
+			{
+				std::lock_guard Lock(RequestState->Mutex);
+				RequestState->PendingRunRequests = ConnectionsWithRuns.Num();
+			}
+
+			for (FProcessingConnectionInfo const& Connection : ConnectionsWithRuns)
+			{
+				AdvViz::SDK::ITwinAPIRequestInfo RunRequestInfo{
+					"GetIModelProcessingStatusRun",
+					AdvViz::SDK::EVerb::Get,
+					TCHAR_TO_UTF8(*Connection.LastRunUrl),
+					"application/vnd.bentley.itwin-platform.v1+json"
+				};
+				RunRequestInfo.CustomHeaders.emplace("Prefer", "return=representation");
+				RunRequestInfo.isFullUrl = true;
+
+				Impl->RunCustomRequest(RunRequestInfo,
+					[IModelId, Connection, RequestState, Finalize](long RunHttpStatus, std::string const& RunResponse,
+						AdvViz::SDK::RequestID const&, std::string& RunError) mutable -> bool
+				{
+					TSharedPtr<FJsonObject> RunResponseJson;
+					if (RunHttpStatus < 200 || RunHttpStatus >= 300
+						|| !ParseJsonObject(RunResponse, RunResponseJson))
+					{
+						RunError = "Failed to parse synchronization run response.";
+						Finalize(false);
+						return false;
+					}
+
+					const TSharedPtr<FJsonObject>* RunObject = nullptr;
+					if (!RunResponseJson->TryGetObjectField(TEXT("run"), RunObject)
+						|| !RunObject || !(*RunObject).IsValid())
+					{
+						RunError = "Synchronization run response is missing 'run'.";
+						Finalize(false);
+						return false;
+					}
+
+					bool bShouldFinalize = false;
+					{
+						std::lock_guard Lock(RequestState->Mutex);
+						UpdateBestProcessingStatus(*RequestState,
+							MakeRunProcessingStatus(IModelId, Connection, *RunObject));
+						if (!RequestState->bFinalized)
+						{
+							RequestState->CompletedRunRequests++;
+							bShouldFinalize =
+								RequestState->CompletedRunRequests >= RequestState->PendingRunRequests;
+						}
+					}
+
+					if (bShouldFinalize)
+					{
+						Finalize(true);
+					}
+					return true;
+				});
+			}
+
+			return true;
+		});
+	});
 }
 
 void UITwinWebServices::DoGetiModelChangesets(FString const& IModelId, bool bRestrictToLatest)

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinWebServices/ITwinWebServicesObserver.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/ITwinWebServices/ITwinWebServicesObserver.cpp
@@ -25,6 +25,10 @@ void FITwinDefaultWebServicesObserver::OnIModelsRetrieved(bool bSuccess, FIModel
 {
 	ensureMsgf(false, TEXT("%s does not handle iModels"), GetObserverName());
 }
+void FITwinDefaultWebServicesObserver::OnIModelProcessingStatusRetrieved(bool bSuccess, FIModelProcessingStatus const& Status)
+{
+	ensureMsgf(false, TEXT("%s does not handle iModel processing status"), GetObserverName());
+}
 void FITwinDefaultWebServicesObserver::OnRealityDataRetrieved(bool bSuccess, FITwinRealityDataInfos const& Infos)
 {
 	ensureMsgf(false, TEXT("%s does not handle RealityData"), GetObserverName());

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Tests/WebServicesTest.cpp
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Private/Tests/WebServicesTest.cpp
@@ -87,6 +87,7 @@ bool FITwinWebServicesTest::RunTest(const FString& /*Parameters*/)
 #define ITWINID_STADIUM_RN_QA "itwinId-Stadium-Ouh-QA"
 #define IMODELID_STADIUM "imodelId-Stadium-023"
 #define CHANGESETID_STADIUM "changesetIdStadium"
+#define IMODELID_SYNC_RUNNING "ef8eb98c-1ba4-4cb9-89f1-5eafcc7c443e"
 
 #define REALITYDATAID_ORLANDO "realityData-Id-Orlando-Magic"
 
@@ -211,6 +212,10 @@ public:
 		if (isUrl(url, "/mesh-export"))
 		{
 			return ProcessMeshExportTest(url, method, data, urlArguments, headers);
+		}
+		if (isUrl(url, "/synchronization"))
+		{
+			return ProcessSynchronizationTest(url, urlArguments, headers);
 		}
 		if (isUrl(url, "/savedviews"))
 		{
@@ -495,6 +500,38 @@ private:
 				"\"_links\":{\"mesh\":{\"href\":\"https://gltf59.blob.net/expId-Turb-53?sv=2024-05-04&spr=https&se=2024-06-22T23%3A59%3A59Z&sr=c&sp=rl&sig=Nq%2B%2FPjEXu64kgPsYVBjuxTV44Zq4GfsSxqTDDygD4oI%3D\"}}}}"
 			);
 		}
+		return Response(MHD_HTTP_NOT_FOUND, "Page not found.");
+	}
+
+	Response ProcessSynchronizationTest(
+		const std::string& url,
+		const std::vector<UrlArg>& urlArguments,
+		const std::vector<Header>& headers) const
+	{
+		CHECK_ITWIN_HEADERS("v1");
+
+		StringMap argMap = ToArgMap(urlArguments);
+		if (url.ends_with("/connections")
+			&& argMap["iModelId"] == IMODELID_SYNC_RUNNING)
+		{
+			const std::string LastRunUrl =
+				"http://localhost:" + std::to_string(getPort())
+				+ "/synchronization/imodels/manifestconnections/manifestConn-Running-01/runs/run-running-01";
+			return Response(MHD_HTTP_OK, std::string("{\"connections\":[")
+				+ "{\"id\":\"manifestConn-Running-01\",\"displayName\":\"Primary synchronization\","
+				+ "\"iModelId\":\"" IMODELID_SYNC_RUNNING "\","
+				+ "\"_links\":{\"lastRun\":{\"href\":\"" + LastRunUrl + "\"}}},"
+				+ "{\"id\":\"manifestConn-Idle-02\",\"displayName\":\"Secondary synchronization\","
+				+ "\"iModelId\":\"" IMODELID_SYNC_RUNNING "\","
+				+ "\"_links\":{}}]}");
+		}
+		if (url.ends_with("/manifestconnections/manifestConn-Running-01/runs/run-running-01"))
+		{
+			return Response(MHD_HTTP_OK,
+				"{\"run\":{\"id\":\"run-running-01\",\"state\":\"Executing\","
+				"\"phase\":\"Synchronization\",\"startDateTime\":\"2026-04-02T16:45:00Z\"}}");
+		}
+
 		return Response(MHD_HTTP_NOT_FOUND, "Page not found.");
 	}
 
@@ -1062,6 +1099,7 @@ public:
 	IMPLEMENT_OBS_CALLBACK(OnITwinInfoRetrieved, AdvViz::SDK::ITwinInfo);
 	IMPLEMENT_OBS_CALLBACK(OnITwinsRetrieved, FITwinInfos);
 	IMPLEMENT_OBS_CALLBACK(OnIModelsRetrieved, FIModelInfos);
+	IMPLEMENT_OBS_CALLBACK(OnIModelProcessingStatusRetrieved, FIModelProcessingStatus);
 	IMPLEMENT_OBS_CALLBACK(OnChangesetsRetrieved, FChangesetInfos);
 
 	IMPLEMENT_OBS_CALLBACK(OnExportInfosRetrieved, FITwinExportInfos);
@@ -1446,6 +1484,28 @@ bool FITwinWebServicesRequestTest::RunTest(const FString& /*Parameters*/)
 		};
 		// (WindTurbine)
 		WebServices->GetiModelChangesets(TEXT(IMODELID_WIND_TURBINE));
+	}
+
+	SECTION("Get iModel Processing Status")
+	{
+		Observer->AddPendingRequest();
+		Observer->OnIModelProcessingStatusRetrievedFunc =
+			[this](bool bSuccess, FIModelProcessingStatus const& Status)
+		{
+			UTEST_TRUE("Get iModel processing status request result", bSuccess);
+			UTEST_EQUAL("IModelId", Status.IModelId, TEXT(IMODELID_SYNC_RUNNING));
+			UTEST_EQUAL("ProcessingStatus", Status.ProcessingStatus, TEXT("synchronization running"));
+			UTEST_EQUAL("ConnectionId", Status.ConnectionId, TEXT("manifestConn-Running-01"));
+			UTEST_EQUAL("ConnectionType", Status.ConnectionType, TEXT("manifest"));
+			UTEST_EQUAL("ConnectionDisplayName", Status.ConnectionDisplayName, TEXT("Primary synchronization"));
+			UTEST_EQUAL("RunId", Status.RunId, TEXT("run-running-01"));
+			UTEST_EQUAL("RunState", Status.RunState, TEXT("Executing"));
+			UTEST_EQUAL("RunPhase", Status.RunPhase, TEXT("Synchronization"));
+			UTEST_EQUAL("StartDateTime", Status.StartDateTime, TEXT("2026-04-02T16:45:00Z"));
+			UTEST_TRUE("bSynchronizationRunning", Status.bSynchronizationRunning);
+			return true;
+		};
+		WebServices->GetIModelProcessingStatus(TEXT(IMODELID_SYNC_RUNNING));
 	}
 
 	FString const WindTurbine_CesiumExportId = TEXT(EXPORTID_WIND_TURBINE_CESIUM);

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Public/ITwinWebServices/ITwinWebServices.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Public/ITwinWebServices/ITwinWebServices.h
@@ -37,6 +37,7 @@ DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnAuthorizationChecked, bool, bSuc
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnGetITwinInfoComplete, bool, bSuccess, FITwinInfo, iTwin);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnGetiTwinsComplete, bool, bSuccess, FITwinInfos, iTwins);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnGetiTwiniModelsComplete, bool, bSuccess, FIModelInfos, iModels);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnGetIModelProcessingStatusComplete, bool, bSuccess, FIModelProcessingStatus, ProcessingStatus);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnGetiModelChangesetsComplete, bool, bSuccess, FChangesetInfos, Changesets);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnGetExportsComplete, bool, bSuccess, FITwinExportInfos, Exports);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnGetExportInfoComplete, bool, bSuccess, FITwinExportInfo, Export);
@@ -116,6 +117,9 @@ public:
 
 	UFUNCTION(BlueprintCallable, Category = "iTwin Web Services")
 	void GetiTwiniModels(FString iTwinId);
+
+	UFUNCTION(BlueprintCallable, Category = "iTwin Web Services")
+	void GetIModelProcessingStatus(FString iModelId);
 
 	UFUNCTION(BlueprintCallable, Category = "iTwin Web Services")
 	void GetiModelChangesets(FString iModelId);
@@ -250,6 +254,9 @@ public:
 
 	UPROPERTY(BlueprintAssignable, Category = "iTwin Web Services")
 	FOnGetiTwiniModelsComplete OnGetiTwiniModelsComplete;
+
+	UPROPERTY(BlueprintAssignable, Category = "iTwin Web Services")
+	FOnGetIModelProcessingStatusComplete OnGetIModelProcessingStatusComplete;
 
 	UPROPERTY(BlueprintAssignable, Category = "iTwin Web Services")
 	FOnGetiModelChangesetsComplete OnGetiModelChangesetsComplete;

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Public/ITwinWebServices/ITwinWebServicesObserver.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Public/ITwinWebServices/ITwinWebServicesObserver.h
@@ -16,6 +16,7 @@
 
 struct FChangesetInfos;
 struct FIModelInfos;
+struct FIModelProcessingStatus;
 struct FITwinInfo;
 struct FITwinInfos;
 struct FITwinExportInfos;
@@ -52,6 +53,7 @@ public:
 	virtual void OnITwinInfoRetrieved(bool bSuccess, AdvViz::SDK::ITwinInfo const& Info) = 0;
 
 	virtual void OnIModelsRetrieved(bool bSuccess, FIModelInfos const& Infos) = 0;
+	virtual void OnIModelProcessingStatusRetrieved(bool bSuccess, FIModelProcessingStatus const& Status) = 0;
 
 	virtual void OnRealityDataRetrieved(bool bSuccess, FITwinRealityDataInfos const& Infos) = 0;
 	virtual void OnRealityData3DInfoRetrieved(bool bSuccess, FITwinRealityData3DInfo const& Info) = 0;
@@ -103,6 +105,7 @@ public:
 	virtual void OnITwinsRetrieved(bool bSuccess, FITwinInfos const& Infos) override;
 	virtual void OnITwinInfoRetrieved(bool bSuccess, AdvViz::SDK::ITwinInfo const& Info) override;
 	virtual void OnIModelsRetrieved(bool bSuccess, FIModelInfos const& Infos) override;
+	virtual void OnIModelProcessingStatusRetrieved(bool bSuccess, FIModelProcessingStatus const& Status) override;
 	virtual void OnRealityDataRetrieved(bool bSuccess, FITwinRealityDataInfos const& Infos) override;
 	virtual void OnRealityData3DInfoRetrieved(bool bSuccess, FITwinRealityData3DInfo const& Info) override;
 	virtual void OnChangesetsRetrieved(bool bSuccess, FChangesetInfos const& ChangesetInfos) override;

--- a/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Public/ITwinWebServices/ITwinWebServices_Info.h
+++ b/Public/UnrealProjects/ITwinTestApp/Plugins/ITwinForUnreal/Source/ITwinRuntime/Public/ITwinWebServices/ITwinWebServices_Info.h
@@ -116,6 +116,48 @@ struct FIModelInfos
 };
 
 USTRUCT(BlueprintType)
+struct FIModelProcessingStatus
+{
+	GENERATED_USTRUCT_BODY()
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		FString IModelId;
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		FString ProcessingStatus;
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		FString ConnectionId;
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		FString ConnectionType;
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		FString ConnectionDisplayName;
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		FString RunId;
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		FString RunState;
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		FString RunResult;
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		FString RunPhase;
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		FString StartDateTime;
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		FString EndDateTime;
+
+	UPROPERTY(BlueprintReadOnly, Category = "iModel Processing")
+		bool bSynchronizationRunning = false;
+};
+
+USTRUCT(BlueprintType)
 struct FChangesetInfo
 {
 	GENERATED_USTRUCT_BODY()


### PR DESCRIPTION
## Summary
- Expand the iTwin web-services API surface and implementation.
- Add observer support and web-services automation coverage.
- Preserve upstream `0.1.28` behavior and exclude assets/build artifacts.

## Validation
- `git diff --check` passes.
- No conflict markers or obvious binary/build artifacts.
- Secret-pattern scan found no credential-like values.
- Full Unreal build/tests remain pending because the local UE 5.6 environment has a Marketplace Cesium plugin collision under `Engine/Plugins/Marketplace`.

This branch is based on the fork's `main`, which is aligned with upstream `0.1.28`.

## Update
Expand the Unreal-facing iTwin web-services API to support scenes containing multiple buildings or iModels that load independently and asynchronously.

A multi-building scene can have several operations active at the same time. Each building may be loading its own iModel data, schedules, metadata, saved views, and 3D tiles. Treating the entire scene as one loading operation makes it difficult to determine which building is ready, which building is still downloading, and which building has failed.

The web-services layer provides a structured way to issue and track these operations without requiring each Unreal application to build its own raw HTTP requests, JSON parsing, callbacks, and error-handling logic.

Observer support allows asynchronous results and state changes to be routed back to the correct runtime object. Responses can be associated with the building, iModel, schedule, or service operation that initiated the request. This prevents data from one building from being applied to another and makes it possible to update each building’s loading state independently.

The API also supports better handling of asynchronous success and failure conditions. One building can continue loading while another reports an error, instead of causing the entire scene to appear stalled or failed.

This work builds on the transport improvements in PR #122. PR #122 provides more reliable requests, response handling, and diagnostics. PR #123 exposes higher-level web-service functionality and asynchronous observation so multiple building workflows can be managed by the Unreal application.

The purpose is to make multi-building iTwin scenes practical to operate and troubleshoot, with independent progress, request tracking, response routing, and failure reporting for each building.